### PR TITLE
`FindlimbusCompanyDirectory()` : 优化路径查找逻辑，新增常量定义

### DIFF
--- a/Datas/Constants.cs
+++ b/Datas/Constants.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LLC_MOD_Toolbox.Datas
+{
+    internal class Constants
+    {
+        public const string GAME_APPID= "1973530";
+
+        public const string MOD_NAME = "LLC_MOD_Toolbox";
+        public const string MOD_VERSION = "1.0.0";
+        public const string MOD_AUTHOR = "LunaticLabs";
+        public const string MOD_DESCRIPTION = "A toolbox for modders to create mods for the game Love Live! School Idol Festival All Stars.";
+    }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -11,6 +11,7 @@
  * 现在请关闭这个文件去玩点别的吧。
 */
 using Downloader;
+using LLC_MOD_Toolbox.Datas;
 using log4net;
 using Microsoft.Win32;
 using Newtonsoft.Json;
@@ -19,6 +20,7 @@ using SimpleJSON;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -578,14 +580,14 @@ namespace LLC_MOD_Toolbox
         /// <summary>
         /// 获取LCB路径
         /// </summary>
-        /// <returns>返回路径。</returns>
+        /// <returns>String 路径</returns>
         private static string? FindlimbusCompanyDirectory()
         {
             logger.Info("使用自动查找边狱公司方法。");
-            if (string.IsNullOrEmpty(LCBPath))
+            if (!string.IsNullOrEmpty(LCBPath))
             {
                 logger.Info("找到了之前获取的路径，检查可用性。");
-                if (File.Exists(LCBPath + "/LimbusCompany.exe"))
+                if (File.Exists(Path.Combine(LCBPath + @"\LimbusCompany.exe")))
                 {
                     logger.Info("路径可用，返回路径。");
                     return LCBPath;
@@ -596,42 +598,22 @@ namespace LLC_MOD_Toolbox
                 }
             }
             string? steamPath = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", null) as string;
-            if (steamPath != null)
-            {
-                string libraryFoldersPath = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
-                if (File.Exists(libraryFoldersPath))
-                {
-                    string[] lines = File.ReadAllLines(libraryFoldersPath);
-                    foreach (string line in lines)
-                    {
-                        if (line.Contains("\t\"path\"\t\t"))
-                        {
-                            string libraryPath = line.Split('\t')[4].Trim('\"');
-
-                            DirectoryInfo[] steamapps = new DirectoryInfo(libraryPath).GetDirectories("steamapps");
-                            if (steamapps.Length > 0)
-                            {
-                                string commonDir = Path.Combine(steamapps[0].FullName, "common");
-                                if (Directory.Exists(commonDir))
-                                {
-                                    DirectoryInfo[] gameDirs = new DirectoryInfo(commonDir).GetDirectories("Limbus Company");
-                                    if (gameDirs.Length > 0)
-                                    {
-                                        var FullName = gameDirs[0].FullName;
-                                        if (File.Exists(FullName + "/LimbusCompany.exe"))
-                                        {
-                                            logger.Info("已自动查找到边狱公司路径，返回路径并保存。");
-                                            return FullName;
-                                        }
-                                    }
-                                }
-                            }
-
-                        }
-                    }
-                }
+            if (steamPath == null) return null;
+            string libraryFoldersPath = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
+            //查找libraryfolders.vdf，中""1973530"\t\t"，并向上找到最近的path
+            try {
+                return Path.Combine(
+                    File.ReadAllLines(libraryFoldersPath).Reverse()
+                    .SkipWhile(n => !n.Contains($"\"{Constants.GAME_APPID}\"\t\t"))
+                    .First(n => n.Contains("path"))
+                    .Split('"')[^2].Replace(@"\\", @"\"),
+                "steamapps","common", "Limbus Company");
             }
-            return null;
+            catch (Exception ex)
+            {
+                logger.Warn(ex+"：游戏未下载或未Steam");
+                return null;
+            }
         }
         /// <summary>
         /// 处理使用Downloader下载文件的事件。


### PR DESCRIPTION
思路是 Limbus 既然依赖 Steam，就不可能不在 vdf 里，出错肯定是因为没有正确下载。

refactor: 优化了 的实现，改用 `LINQ` 反向查找 `libraryfolders.vdf` 文件中的路径，替换了原有的复杂路径查找逻辑。logger触发改为Exception。（因为split无法实现不抛异常，至少我不会）

chore: 在 `Constants.cs` 文件中新增了 `LLC_MOD_Toolbox.Datas` 命名空间，并预先定义了一个 `Constants` 类，包含游戏的 `GAME_APPID`、MOD 的名称、版本、作者和描述等常量。

chore: 改了返回的注释。

null: 添加了 Herobrine 。Change Readme