### PR TITLE
复活工具箱

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Configuration;
 using System.Data;
 using System.Windows;
+using static LLC_MOD_Toolbox.MainWindow;
 
 [assembly: log4net.Config.XmlConfigurator(ConfigFile = "App.config", ConfigFileExtension = "config", Watch = true)]
 namespace LLC_MOD_Toolbox
@@ -10,5 +11,31 @@ namespace LLC_MOD_Toolbox
     /// </summary>
     public partial class App : System.Windows.Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            this.DispatcherUnhandledException += App_DispatcherUnhandledException; ;
+        }
+        //本次运行出现的问题次数
+        private static int error_count = 0;
+        //程序出错的次数上限
+        private static int max_error_count = 5;
+        private void App_DispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+        {
+            Exception ex = e.Exception;
+            logger.Error("出现了问题：\n", ex);
+            string errorMessage = ReturnExceptionText(ex);
+            System.Windows.MessageBox.Show($"出现了未经处理的问题\n也许工具箱能够正常运行，不过建议检查日志并寻求帮助\n错误原因：{errorMessage}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            if (error_count <= max_error_count)
+            {
+                error_count++;
+                e.Handled = true;
+            }
+            else
+            {
+                System.Windows.MessageBox.Show("多次出现错误，即将关闭程序", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+                e.Handled = false;
+            }
+        }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -361,9 +361,18 @@ namespace LLC_MOD_Toolbox
             try
             {
                 logger.Debug("更改彩蛋图片为： " + url);
+
                 await this.Dispatcher.BeginInvoke(() =>
                 {
-                    EEPageImage.Source = BitmapFrame.Create(new Uri(url), BitmapCreateOptions.None, BitmapCacheOption.Default);
+                    try
+                    {
+                    Uri uri = new Uri(url);
+                        EEPageImage.Source = BitmapFrame.Create(uri, BitmapCreateOptions.None, BitmapCacheOption.Default);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex.ToString());
+                    }
                 });
             }
             catch

--- a/NodeList.json
+++ b/NodeList.json
@@ -1,21 +1,26 @@
 ﻿{
-  "downloadNode": [
-    {
-      "name": "自动选择节点",
-      "endpoint": "https://api.zeroasso.top/v2/download/files?file_name={0}",
-      "isDefault": true
-    },
-    {
-      "name": "零协会镇江节点",
-      "endpoint": "http://download.zeroasso.top/files/{0}",
-      "isDefault": false
-    },
-    {
-      "name": "天翼云盘",
-      "endpoint": "https://node.zeroasso.top/d/tianyi/{0}",
-      "isDefault": false
-    }
-  ],
+    "downloadNode": [
+        {
+            "name": "自动选择节点",
+            "endpoint": "https://api.zeroasso.top/v2/download/files?file_name={0}",
+            "isDefault": false
+        },
+        {
+            "name": "零协会镇江节点",
+            "endpoint": "http://download.zeroasso.top/files/{0}",
+            "isDefault": false
+        },
+        {
+            "name": "零协会临时节点",
+            "endpoint": "http://download.zeroasso.top/files/{0}",
+            "isDefault": true
+        },
+        {
+            "name": "Github直连",
+            "endpoint": "https://github.com/LocalizeLimbusCompany/LLC_Release/releases/download/{0}",
+            "isDefault": false
+        }
+    ],
   "apiNode": [
     {
       "name": "零协会官方 API",


### PR DESCRIPTION
去除mod下载和验证，修改资源下载逻辑，并且适配目前临时资源的下载，工具箱目前可以正常使用。
另外添加

1. 捕捉任何错误并记录到log的功能，增加debug效率
2. 二次自动寻路逻辑，解决在steam中移动过Limbus Company安装位置的情况下无法自动识别路径。


部分功能还需要等待配置各节点新的资源下载地址后才可以实现