### PR TITLE
fix: 当替换字体文件无效时的程序崩溃

### DIFF
--- a/MainWindowWD.xaml.cs
+++ b/MainWindowWD.xaml.cs
@@ -2565,6 +2565,7 @@ del /f /q ""{batPath}""
             {
                 Log.logger.Info("字体文件无效。");
                 UniversalDialog.ShowMessage("字体文件无效。", "提示", null, this);
+                return;
             }
             if (File.Exists(oldFontPath) && !File.Exists(backupFontPath))
             {


### PR DESCRIPTION
在字体文件无效时 `切换字体` 就会崩溃.

因为在判断字体无效后并没有退出替换逻辑, 
如果字体文件不存在就会发生错误.