### PR TITLE
ci: update mirrorchyan uploading

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -2,8 +2,10 @@ name: mirrorchyan_release
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+    inputs:
+      tag:
+        default: ''
+        required: false
 
 jobs:
   mirrorchyan:
@@ -15,8 +17,28 @@ jobs:
           filetype: latest-release
           filename: "LLC_MOD_Toolbox_Installer.exe"
           mirrorchyan_rid: LLC_MOD_Toolbox
+          tag: ${{ inputs.tag }}
 
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          os: win
+          arch: x64
+
           owner: LocalizeLimbusCompany
           repo: LLC_MOD_Toolbox
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}
+
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: "LLC_MOD_Toolbox.7z"
+          mirrorchyan_rid: LLC_MOD_Toolbox_Increment
+          tag: ${{ inputs.tag }}
+          p7zip: true
+
+          os: win
+          arch: x64
+
+          owner: LocalizeLimbusCompany
+          repo: LLC_MOD_Toolbox
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -2,8 +2,12 @@ name: mirrorchyan_release_note
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        default: ''
+        required: false
   release:
-    types: [released, edited]
+    types: [edited]
 
 jobs:
   mirrorchyan:
@@ -14,8 +18,20 @@ jobs:
         uses: MirrorChyan/release-note-action@v1
         with:
           mirrorchyan_rid: LLC_MOD_Toolbox
+          version_name: ${{ inputs.tag }}
 
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           owner: LocalizeLimbusCompany
           repo: LLC_MOD_Toolbox
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}
+
+      - id: uploading_increment
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: LLC_MOD_Toolbox_Increment
+          version_name: ${{ inputs.tag }}
+
+          owner: LocalizeLimbusCompany
+          repo: LLC_MOD_Toolbox
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,11 @@ jobs:
             LLC_MOD_Toolbox_Installer.exe
           token: ${{ secrets.GITHUB_TOKEN }}
           generate_release_notes: true
+
+      - name: Trigger MirrorChyanUploading
+        shell: bash
+        run: |
+          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ github.ref_name }}
+          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
更新 Mirror酱(MirrorChyan) 分发服务集成。

### 变更内容

- **mirrorchyan_release.yml**：更新到最新模板格式（添加 `tag` input、`os`/`arch` 字段），新增 `LLC_MOD_Toolbox_Increment` 增量包上传
- **mirrorchyan_release_note.yml**：更新到最新模板格式（添加 `tag` input、`version_name` 字段），新增 `LLC_MOD_Toolbox_Increment` release note 同步
- **release.yml**：在 Publish Release Assets 步骤后添加 Trigger MirrorChyanUploading 步骤，自动触发 Mirror酱上传